### PR TITLE
chore: Add target blank to socials

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,6 +28,7 @@ export default function Footer() {
           href="https://twitter.com/Gita_GPT"
           className="group"
           aria-label="Gita GPT on Twitter"
+          target="blank"
         >
           <svg
             aria-hidden="true"
@@ -40,6 +41,7 @@ export default function Footer() {
           href="https://github.com/snypiie/gitagpt"
           className="group"
           aria-label="Gita GPT on GitHub"
+          target="blank"
         >
           <svg
             aria-hidden="true"
@@ -53,6 +55,7 @@ export default function Footer() {
           href="https://facebook.com/gitagpt"
           className="group"
           aria-label="Gita GPT on Facebook"
+          target="blank"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
It really is irritating when you are getting life advice from Chanakya or lord krishna and you get curious about the code base, so you click the github icon and it open github in the same tab and deleted all of the advice lord krishna gave you 😢 . So, my small part to the great work. 

I chose "blank" over "_blank" so as not to create multiple tabs. Ciao!

P.S: Not sure why the build is failing, can you attach a screenshot of the reason?